### PR TITLE
fix: release missing es5 build, build by default with prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "test": "jest",
     "build:es5": "./node_modules/.bin/babel src -d lib",
-    "build": "yarn build:es5 && yarn test"
+    "build": "yarn build:es5 && yarn test",
+    "prepublish": "npm run build:es5"
   },
   "jest": {
     "coverageDirectory": "./coverage/",


### PR DESCRIPTION
Last release 0.0.2 did not have an up to date es5 build, the 0.0.2 references code from 0.0.1. So jwt verification which required auth material was failing in did-jwt/uport-js. 

Added prepublish script for future, but also need a 0.0.3 released with updates. 